### PR TITLE
feat: allow using default VPC

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,36 +2,60 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.34.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecr_repository.repository](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
+| [aws_ecs_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_service.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_access_key.publisher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
+| [aws_iam_role.fargate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.fargate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_user.publisher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy.publisher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
+| [aws_lb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.front_end](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_subnet.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnet_ids.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aws\_region | AWS region | `string` | `"eu-west-3"` | no |
-| container | Container configuration to deploy | `any` | `{}` | no |
-| ecr\_values | AWS ECR configuration | `any` | `{}` | no |
-| ecs\_values | AWS ECS configuration | `any` | `{}` | no |
-| lb\_values | AWS Load Balancer configuration | `any` | `{}` | no |
-| vpc\_values | AWS Load Balancer configuration | `any` | `{}` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-3"` | no |
+| <a name="input_container"></a> [container](#input\_container) | Container configuration to deploy | `any` | `{}` | no |
+| <a name="input_ecr_values"></a> [ecr\_values](#input\_ecr\_values) | AWS ECR configuration | `any` | `{}` | no |
+| <a name="input_ecs_values"></a> [ecs\_values](#input\_ecs\_values) | AWS ECS configuration | `any` | `{}` | no |
+| <a name="input_lb_values"></a> [lb\_values](#input\_lb\_values) | AWS Load Balancer configuration | `any` | `{}` | no |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | AWS VPC configuration | `any` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| app\_url | The public ALB DNS |
-| aws\_region | The AWS region used |
-| container\_name | Container name for the ECS task |
-| ecr\_repository\_name | The ECR repository name |
-| ecr\_url | The ECR repository URL |
-| ecs\_cluster | The ECS cluster name |
-| ecs\_service | The ECS service name |
-| publisher\_access\_key | AWS\_ACCESS\_KEY to publish to ECR |
-| publisher\_secret\_key | AWS\_SECRET\_ACCESS\_KEY to upload to the ECR |
-
+| <a name="output_app_url"></a> [app\_url](#output\_app\_url) | The public ALB DNS |
+| <a name="output_aws_region"></a> [aws\_region](#output\_aws\_region) | The AWS region used |
+| <a name="output_container_name"></a> [container\_name](#output\_container\_name) | Container name for the ECS task |
+| <a name="output_ecr_repository_name"></a> [ecr\_repository\_name](#output\_ecr\_repository\_name) | The ECR repository name |
+| <a name="output_ecr_url"></a> [ecr\_url](#output\_ecr\_url) | The ECR repository URL |
+| <a name="output_ecs_cluster"></a> [ecs\_cluster](#output\_ecs\_cluster) | The ECS cluster name |
+| <a name="output_ecs_service"></a> [ecs\_service](#output\_ecs\_service) | The ECS service name |
+| <a name="output_publisher_access_key"></a> [publisher\_access\_key](#output\_publisher\_access\_key) | AWS\_ACCESS\_KEY to publish to ECR |
+| <a name="output_publisher_secret_key"></a> [publisher\_secret\_key](#output\_publisher\_secret\_key) | AWS\_SECRET\_ACCESS\_KEY to upload to the ECR |

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,13 +1,3 @@
-data "aws_vpc" "main" {
-  id = local.vpc["id"]
-}
-
-data "aws_subnet" "subnets" {
-  for_each          = toset(local.vpc.availability_zones)
-  vpc_id            = data.aws_vpc.main.id
-  availability_zone = each.value
-}
-
 resource "aws_lb" "alb" {
   name               = local.lb["name"]
   internal           = local.lb["internal"]
@@ -19,7 +9,7 @@ resource "aws_lb_target_group" "group" {
   name        = local.lb.target_group["name"]
   port        = local.lb.target_group["port"]
   protocol    = local.lb.target_group["protocol"]
-  vpc_id      = data.aws_vpc.main.id
+  vpc_id      = data.aws_vpc.vpc.id
   target_type = "ip"
 
   depends_on = [aws_lb.alb]

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -23,10 +23,10 @@ locals {
   lb = merge(local.lb_defaults, var.lb_values)
 
   vpc_defaults = {
-    id                 = "vpc-ef26d387"
-    availability_zones = ["${local.region}a", "${local.region}b", "${local.region}c"]
+    id = ""
   }
-  vpc = merge(local.vpc_defaults, var.vpc_values)
+  vpc             = merge(local.vpc_defaults, var.vpc)
+  use_default_vpc = local.vpc.id == ""
 
   container_defaults = {
     name  = "application"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,3 +1,7 @@
 container = {
   image = "particule/helloworld"
 }
+
+vpc = {
+  id = "vpc-ef26d387"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,10 +22,10 @@ variable "lb_values" {
   description = "AWS Load Balancer configuration"
 }
 
-variable "vpc_values" {
+variable "vpc" {
   type        = any
   default     = {}
-  description = "AWS Load Balancer configuration"
+  description = "AWS VPC configuration"
 }
 
 variable "container" {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,15 @@
+data "aws_vpc" "vpc" {
+  id      = local.use_default_vpc ? null : local.vpc["id"]
+  default = local.use_default_vpc
+}
+
+data "aws_subnet_ids" "subnets" {
+  vpc_id = data.aws_vpc.vpc.id
+}
+
+data "aws_subnet" "subnets" {
+  for_each = data.aws_subnet_ids.subnets.ids
+  vpc_id   = data.aws_vpc.vpc.id
+  id       = each.value
+  # availability_zone = each.value
+}


### PR DESCRIPTION
- feat(tf): allow using default vpc
- feat(terraform): specify vpc id in tfvars

Not specifying the `local.vpc.id` will make terraform look for the default VPC in the selected AWS region.

Closes #1
